### PR TITLE
Make geocode provider references generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The code requires several environment variables to set for it to work:
 export FORD_USERNAME="<your fordpass username>"
 export FORD_PASSWORD="<your fordpass password>"
 export VIN="<your vehicle VIN number>"
-export MAPS_API_KEY="<a geocodio maps api key>" // this is optional
+export GEOCODE_PROVIDER="<a geocode provider>" // this is optional, see https://www.npmjs.com/package/node-geocoder#geocoder-providers-in-alphabetical-order for provider options
+export GEOCODE_API_KEY="<a geocode provider api key>" // this is optional
 ```
 
 Once you have those thing setup you can issue commands and check the status of your vehicle like this:

--- a/index.js
+++ b/index.js
@@ -2,14 +2,16 @@ const argv = require('yargs').argv
 const fordApi = require('ffpass')
 const NGo = require('node-geocoder')
 const code = require('http-status-code')
-const googleMapsApiKey = process.env.MAPS_API_KEY
+const geocodeProvider = process.env.GEOCODE_PROVIDER
+const geocodeProviderApiKey = process.env.GEOCODE_API_KEY
 const car = new fordApi.vehicle(process.env.FORD_USERNAME, process.env.FORD_PASSWORD, process.env.VIN)
  
-// setup the google maps api for looking up address info from gps coordinates
+// setup a geocode api provider to convert from GPS coordinates to an address
+// see https://www.npmjs.com/package/node-geocoder#geocoder-providers-in-alphabetical-order for provider options
 var geoOptions = {
-    provider: 'geocodio',
+    provider: geocodeProvider,
     httpAdapter: 'https',
-    apiKey: googleMapsApiKey,
+    apiKey: geocodeProviderApiKey,
 }
 var geocoder = NGo(geoOptions)
 


### PR DESCRIPTION
There's currently a mismatch between for the geocode provider as we're statically configuring Geocodio but requesting a Google Maps API key:
https://github.com/d4v3y0rk/ffpass/blob/20cbc5ed6dabf1b9e18bc2efbcc5c6237647ab85/index.js#L9-L13

This PR generalizes the geocode provider, adding another ENV var to define the provider and the associated key. Documentation has been updated to reflect this including a link to valid providers based on the `node-geocoder` dependency.